### PR TITLE
Enables binance_tokio_client to be used within async context and Tokio::Spawn runtime

### DIFF
--- a/src/hyper/client.rs
+++ b/src/hyper/client.rs
@@ -109,6 +109,7 @@ where
             url_parts.push(query_string);
         }
         let uri: Uri = url_parts.join("").parse()?;
+        log::debug!("{}", uri);
         let hyper_request = hyper_request.uri(uri);
         let request = hyper_request
             .body(Body::empty())
@@ -118,6 +119,7 @@ where
             .request(request)
             .await
             .map_err(|err| Error::Send(err))?;
+        log::debug!("{}", response.status());
         Ok(Response::from(response))
     }
 }


### PR DESCRIPTION
This PR enables binance_spot_connector with Hyper client to be used within async contexts and Tokio runtime.

## Problem

Using hyper client within tokio::spawn throws an error.

```rust
tokio::spawn(async move {
  // ...
  //  Doing something with hyper client
  // ...
})
```

The problem lies with `url::form_urlencoded::Serializer` which is not [Send](https://doc.rust-lang.org/std/marker/trait.Send.html) and there for cannot be carried across an await.

Using it within Tokio context throws an error on line `/src/hyper/client.rs:117:13`:
```rust
let response = self
            .client
            .request(request)
            .await // <--------------------------- Throws here
            .map_err(|err| Error::Send(err))?;

// ...
    = help: the trait `Sync` is not implemented for `dyn for<'a> Fn(&'a s
note: future is not `Send` as this value is used across an await
   --> /binance_spot_connector_rust-1.0.1/src/hyper/client.rs:117:13
    |
68  |         let mut serializer = url::form_urlencoded::Serializer::n...
    |             -------------- has type `form_urlencoded::Serializer<'_, std::string::String>` which is not `Send`
...
117 |             .await
    |             ^^^^^^ await occurs here, with `mut serializer` maybe used later
...
122 |     }
    |     - `mut serializer` is later dropped here
note: required by a bound in `tokio::spawn`
```

## Solution

The fix is to put the serializer in a block so it drops before it could cross an await and it works like a charm :)