### PR TITLE
add subscription from slice of Streams

### DIFF
--- a/src/tungstenite.rs
+++ b/src/tungstenite.rs
@@ -82,6 +82,11 @@ impl<T: Read + Write> WebSocketState<T> {
         self.send("SUBSCRIBE", streams.into_iter().map(|s| s.as_str()))
     }
 
+    pub fn subscribe_from_slice(&mut self, streams: &[Stream]) -> u64
+    {
+        self.send("SUBSCRIBE", streams.iter().map(|s| s.as_str()))
+    }
+
     /// Sends `UNSUBSCRIBE` message for the given `streams`.
     ///
     /// `streams` are not validated. Non-existing streams will be


### PR DESCRIPTION
Now, it is possible to use a dynamic list of symbols for subscribing.

```rust
let symbol_lst = vec!["BTCUSDT".to_string(), "BNBBUSD".to_string(), "BTCUSDT".to_string()];

let lst = symbol_lst.iter()
    .map(|x| BookTickerStream::from_symbol(&x).into())
    .collect::<Vec<_>>()
    ;
conn.subscribe_from_slice(&lst);
```

fixes #9 