### PR TITLE
fix: correct NewUmAlgoOrderTypeEnum for portfolio margin UM algo conditional orders

### DIFF
--- a/examples/derivatives_trading_portfolio_margin/rest_api/trade_api/new_um_algo_order.rs
+++ b/examples/derivatives_trading_portfolio_margin/rest_api/trade_api/new_um_algo_order.rs
@@ -30,10 +30,10 @@ async fn main() -> Result<()> {
 
     // Setup the API parameters
     let params = NewUmAlgoOrderParams::builder(
-        "algo_type_example".to_string(),
+        "CONDITIONAL".to_string(),
         "symbol_example".to_string(),
         NewUmAlgoOrderSideEnum::Buy,
-        NewUmAlgoOrderTypeEnum::Limit,
+        NewUmAlgoOrderTypeEnum::StopMarket,
         dec!(1.0),
     )
     .build()?;

--- a/src/derivatives_trading_portfolio_margin/rest_api/apis/trade_api.rs
+++ b/src/derivatives_trading_portfolio_margin/rest_api/apis/trade_api.rs
@@ -1275,18 +1275,27 @@ impl std::str::FromStr for NewUmAlgoOrderSideEnum {
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum NewUmAlgoOrderTypeEnum {
-    #[serde(rename = "LIMIT")]
-    Limit,
-    #[serde(rename = "MARKET")]
-    Market,
+    #[serde(rename = "STOP")]
+    Stop,
+    #[serde(rename = "STOP_MARKET")]
+    StopMarket,
+    #[serde(rename = "TAKE_PROFIT")]
+    TakeProfit,
+    #[serde(rename = "TAKE_PROFIT_MARKET")]
+    TakeProfitMarket,
+    #[serde(rename = "TRAILING_STOP_MARKET")]
+    TrailingStopMarket,
 }
 
 impl NewUmAlgoOrderTypeEnum {
     #[must_use]
     pub fn as_str(&self) -> &'static str {
         match self {
-            Self::Limit => "LIMIT",
-            Self::Market => "MARKET",
+            Self::Stop => "STOP",
+            Self::StopMarket => "STOP_MARKET",
+            Self::TakeProfit => "TAKE_PROFIT",
+            Self::TakeProfitMarket => "TAKE_PROFIT_MARKET",
+            Self::TrailingStopMarket => "TRAILING_STOP_MARKET",
         }
     }
 }
@@ -1296,8 +1305,11 @@ impl std::str::FromStr for NewUmAlgoOrderTypeEnum {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "LIMIT" => Ok(Self::Limit),
-            "MARKET" => Ok(Self::Market),
+            "STOP" => Ok(Self::Stop),
+            "STOP_MARKET" => Ok(Self::StopMarket),
+            "TAKE_PROFIT" => Ok(Self::TakeProfit),
+            "TAKE_PROFIT_MARKET" => Ok(Self::TakeProfitMarket),
+            "TRAILING_STOP_MARKET" => Ok(Self::TrailingStopMarket),
             other => Err(format!("invalid NewUmAlgoOrderTypeEnum: {}", other).into()),
         }
     }
@@ -3613,7 +3625,7 @@ pub struct NewUmAlgoOrderParams {
     /// This field is **required.
     #[builder(setter(into))]
     pub side: NewUmAlgoOrderSideEnum,
-    /// `LIMIT`, `MARKET`
+    /// `STOP`, `STOP_MARKET`, `TAKE_PROFIT`, `TAKE_PROFIT_MARKET`, `TRAILING_STOP_MARKET`
     ///
     /// This field is **required.
     #[builder(setter(into))]
@@ -11939,7 +11951,7 @@ mod tests {
         TOKIO_SHARED_RT.block_on(async {
             let client = MockTradeApiClient { force_error: false };
 
-            let params = NewUmAlgoOrderParams::builder("algo_type_example".to_string(),"symbol_example".to_string(),NewUmAlgoOrderSideEnum::Buy,NewUmAlgoOrderTypeEnum::Limit,dec!(1.0),).build().unwrap();
+            let params = NewUmAlgoOrderParams::builder("algo_type_example".to_string(),"symbol_example".to_string(),NewUmAlgoOrderSideEnum::Buy,NewUmAlgoOrderTypeEnum::StopMarket,dec!(1.0),).build().unwrap();
 
             let resp_json: Value = serde_json::from_str(r#"{"algoId":2146760,"clientAlgoId":"6B2I9XVcJpCjqPAJ4YoFX7","algoType":"CONDITIONAL","orderType":"TAKE_PROFIT","symbol":"BNBUSDT","side":"SELL","positionSide":"BOTH","timeInForce":"GTC","quantity":"0.01","algoStatus":"NEW","triggerPrice":"750.000","price":"750.000","icebergQuantity":null,"selfTradePreventionMode":"EXPIRE_MAKER","workingType":"CONTRACT_PRICE","priceMatch":"NONE","priceProtect":false,"reduceOnly":false,"activatePrice":"","callbackRate":"","createTime":1750485492076,"updateTime":1750485492076,"triggerTime":0,"goodTillDate":0}"#).unwrap();
             let expected_response : models::NewUmAlgoOrderResponse = serde_json::from_value(resp_json.clone()).expect("should parse into models::NewUmAlgoOrderResponse");
@@ -11956,7 +11968,7 @@ mod tests {
         TOKIO_SHARED_RT.block_on(async {
             let client = MockTradeApiClient { force_error: false };
 
-            let params = NewUmAlgoOrderParams::builder("algo_type_example".to_string(),"symbol_example".to_string(),NewUmAlgoOrderSideEnum::Buy,NewUmAlgoOrderTypeEnum::Limit,dec!(1.0),).position_side(NewUmAlgoOrderPositionSideEnum::Both).time_in_force(NewUmAlgoOrderTimeInForceEnum::Gtc).price(dec!(1.0)).trigger_price(dec!(1.0)).working_type(NewUmAlgoOrderWorkingTypeEnum::MarkPrice).price_match(NewUmAlgoOrderPriceMatchEnum::None).price_protect("false".to_string()).reduce_only("false".to_string()).activate_price(dec!(1.0)).callback_rate(dec!(1.0)).client_algo_id("1".to_string()).new_order_resp_type(NewUmAlgoOrderNewOrderRespTypeEnum::Ack).self_trade_prevention_mode(NewUmAlgoOrderSelfTradePreventionModeEnum::None).good_till_date(789).recv_window(5000).build().unwrap();
+            let params = NewUmAlgoOrderParams::builder("algo_type_example".to_string(),"symbol_example".to_string(),NewUmAlgoOrderSideEnum::Buy,NewUmAlgoOrderTypeEnum::StopMarket,dec!(1.0),).position_side(NewUmAlgoOrderPositionSideEnum::Both).time_in_force(NewUmAlgoOrderTimeInForceEnum::Gtc).price(dec!(1.0)).trigger_price(dec!(1.0)).working_type(NewUmAlgoOrderWorkingTypeEnum::MarkPrice).price_match(NewUmAlgoOrderPriceMatchEnum::None).price_protect("false".to_string()).reduce_only("false".to_string()).activate_price(dec!(1.0)).callback_rate(dec!(1.0)).client_algo_id("1".to_string()).new_order_resp_type(NewUmAlgoOrderNewOrderRespTypeEnum::Ack).self_trade_prevention_mode(NewUmAlgoOrderSelfTradePreventionModeEnum::None).good_till_date(789).recv_window(5000).build().unwrap();
 
             let resp_json: Value = serde_json::from_str(r#"{"algoId":2146760,"clientAlgoId":"6B2I9XVcJpCjqPAJ4YoFX7","algoType":"CONDITIONAL","orderType":"TAKE_PROFIT","symbol":"BNBUSDT","side":"SELL","positionSide":"BOTH","timeInForce":"GTC","quantity":"0.01","algoStatus":"NEW","triggerPrice":"750.000","price":"750.000","icebergQuantity":null,"selfTradePreventionMode":"EXPIRE_MAKER","workingType":"CONTRACT_PRICE","priceMatch":"NONE","priceProtect":false,"reduceOnly":false,"activatePrice":"","callbackRate":"","createTime":1750485492076,"updateTime":1750485492076,"triggerTime":0,"goodTillDate":0}"#).unwrap();
             let expected_response : models::NewUmAlgoOrderResponse = serde_json::from_value(resp_json.clone()).expect("should parse into models::NewUmAlgoOrderResponse");
@@ -11977,7 +11989,7 @@ mod tests {
                 "algo_type_example".to_string(),
                 "symbol_example".to_string(),
                 NewUmAlgoOrderSideEnum::Buy,
-                NewUmAlgoOrderTypeEnum::Limit,
+                NewUmAlgoOrderTypeEnum::StopMarket,
                 dec!(1.0),
             )
             .build()


### PR DESCRIPTION
### Description

The `NewUmAlgoOrderTypeEnum` in the Portfolio Margin module has incorrect variants (`LIMIT` and `MARKET`) that are not accepted by the Binance API for conditional algo orders. This makes it impossible to place take-profit, stop-loss, or trailing stop orders via the `/papi/v1/um/algo/order` endpoint using the SDK.

### Background

When integrating the Portfolio Margin UM algo endpoint for conditional orders (TP/SL/Trailing Stop), we discovered two issues through systematic testing:

1. **UM Conditional endpoints (`/papi/v1/um/conditional/*`) return 404** — All 7 conditional endpoints documented by Binance return HTTP 404 on the live server. The CM conditional endpoints work correctly. These methods are already marked as `#[deprecated]` in the SDK.

2. **`NewUmAlgoOrderTypeEnum` has wrong variants** — The enum contains `LIMIT` and `MARKET`, but the Binance API only accepts `STOP`, `STOP_MARKET`, `TAKE_PROFIT`, `TAKE_PROFIT_MARKET`, and `TRAILING_STOP_MARKET` for conditional algo orders. Using `LIMIT` or `MARKET` returns: `{"code":-1130,"msg":"Data sent for parameter 'orderType' is not valid."}`

This PR fixes issue #2. Issue #1 is a Binance server-side concern (endpoints documented but not deployed).

### Changes

- **`NewUmAlgoOrderTypeEnum`** — Replaced `Limit`/`Market` with `Stop`/`StopMarket`/`TakeProfit`/`TakeProfitMarket`/`TrailingStopMarket`
- Updated `as_str()` and `FromStr` implementations accordingly
- Updated the doc comment on `NewUmAlgoOrderParams.type` field to list correct values
- Updated example file to use `StopMarket` with `algoType = "CONDITIONAL"`
- Updated 3 test cases to use the new `StopMarket` variant

### Verification

**Static checks:**
- `cargo build --features derivatives_trading_portfolio_margin` — passed
- `cargo test --features derivatives_trading_portfolio_margin` — 189 tests passed, 0 failed
- `cargo clippy --features derivatives_trading_portfolio_margin -- -D warnings` — no warnings

**Live API end-to-end testing** (against Binance production with a Portfolio Margin unified account):

| Scenario | Result |
|----------|--------|
| Market order to open position | ✅ |
| TAKE_PROFIT_MARKET (take-profit) | ✅ |
| STOP_MARKET (stop-loss) | ✅ |
| STOP with price (limit stop-loss) | ✅ |
| TRAILING_STOP_MARKET (trailing stop) | ✅ |
| Query open algo orders | ✅ |
| Query single algo order by algoId | ✅ |
| Cancel individual algo order | ✅ |
| Batch cancel all algo orders | ✅ |
| Modify TP/SL (cancel + re-place) | ✅ |
| Market order to close position | ✅ |
| Confirm no residual orders/positions | ✅ |

**API response verification** — Using the old `LIMIT`/`MARKET` types returns `-1130` error; all 5 new types are accepted and produce correct orders with matching `orderType` in the response.

### Files Changed

- `src/derivatives_trading_portfolio_margin/rest_api/apis/trade_api.rs` — enum definition, doc comment, tests
- `examples/derivatives_trading_portfolio_margin/rest_api/trade_api/new_um_algo_order.rs` — example update