### PR TITLE
fix: support conditional UM algo order types without breaking compatibility

### DIFF
--- a/src/derivatives_trading_portfolio_margin/rest_api/apis/trade_api.rs
+++ b/src/derivatives_trading_portfolio_margin/rest_api/apis/trade_api.rs
@@ -1275,10 +1275,28 @@ impl std::str::FromStr for NewUmAlgoOrderSideEnum {
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum NewUmAlgoOrderTypeEnum {
+    #[deprecated(
+        since = "1.0.0",
+        note = "Binance API returns -1130 for LIMIT/MARKET in conditional algo orders. Use Stop or StopMarket instead."
+    )]
     #[serde(rename = "LIMIT")]
     Limit,
+    #[deprecated(
+        since = "1.0.0",
+        note = "Binance API returns -1130 for LIMIT/MARKET in conditional algo orders. Use Stop or StopMarket instead."
+    )]
     #[serde(rename = "MARKET")]
     Market,
+    #[serde(rename = "STOP")]
+    Stop,
+    #[serde(rename = "STOP_MARKET")]
+    StopMarket,
+    #[serde(rename = "TAKE_PROFIT")]
+    TakeProfit,
+    #[serde(rename = "TAKE_PROFIT_MARKET")]
+    TakeProfitMarket,
+    #[serde(rename = "TRAILING_STOP_MARKET")]
+    TrailingStopMarket,
 }
 
 impl NewUmAlgoOrderTypeEnum {
@@ -1287,6 +1305,11 @@ impl NewUmAlgoOrderTypeEnum {
         match self {
             Self::Limit => "LIMIT",
             Self::Market => "MARKET",
+            Self::Stop => "STOP",
+            Self::StopMarket => "STOP_MARKET",
+            Self::TakeProfit => "TAKE_PROFIT",
+            Self::TakeProfitMarket => "TAKE_PROFIT_MARKET",
+            Self::TrailingStopMarket => "TRAILING_STOP_MARKET",
         }
     }
 }
@@ -1298,6 +1321,11 @@ impl std::str::FromStr for NewUmAlgoOrderTypeEnum {
         match s {
             "LIMIT" => Ok(Self::Limit),
             "MARKET" => Ok(Self::Market),
+            "STOP" => Ok(Self::Stop),
+            "STOP_MARKET" => Ok(Self::StopMarket),
+            "TAKE_PROFIT" => Ok(Self::TakeProfit),
+            "TAKE_PROFIT_MARKET" => Ok(Self::TakeProfitMarket),
+            "TRAILING_STOP_MARKET" => Ok(Self::TrailingStopMarket),
             other => Err(format!("invalid NewUmAlgoOrderTypeEnum: {}", other).into()),
         }
     }


### PR DESCRIPTION
## Summary

Refactors `NewUmAlgoOrderTypeEnum` to support the conditional algo order types actually accepted by the Binance API for portfolio margin UM algo orders, while preserving backwards compatibility.

## Changes

- keeps existing `LIMIT` and `MARKET` variants
- marks both as deprecated instead of removing them
- adds:
  - `Stop`
  - `StopMarket`
  - `TakeProfit`
  - `TakeProfitMarket`
  - `TrailingStopMarket`
- updates `as_str()` mappings
- updates `FromStr` mappings

## Why

The Binance API accepts the following conditional algo order types for these orders:

- `STOP`
- `STOP_MARKET`
- `TAKE_PROFIT`
- `TAKE_PROFIT_MARKET`
- `TRAILING_STOP_MARKET`

Using `LIMIT` or `MARKET` for these conditional algo orders results in `-1130`.

This patch fixes the enum without introducing a breaking change for existing SDK users.

## Compatibility

`LIMIT` and `MARKET` are intentionally preserved and marked as deprecated:

> Binance API returns -1130 for LIMIT/MARKET in conditional algo orders. Use Stop or StopMarket instead.

## Notes

This is intentionally narrower than replacing the old variants outright. The goal is to correct API behavior while maintaining source compatibility for downstream users.


Related: #94

This patch takes the same issue in a backwards-compatible direction by preserving the old variants as deprecated instead of removing them.
