### PR TITLE
fix(ws): don't schedule reconnect when closing a renewed connection

### DIFF
--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -1,11 +1,12 @@
 use thiserror::Error;
+use tokio_tungstenite::tungstenite::error::ProtocolError;
 
 /// Represents different types of WebSocket connection failures and their reconnection eligibility
 #[derive(Debug, Clone, Copy)]
 pub enum WebsocketConnectionFailureReason {
     /// Network-level interruption (should reconnect)
     NetworkInterruption,
-    /// Connection reset by peer (should reconnect)  
+    /// Connection reset by peer (should reconnect)
     ConnectionReset,
     /// Server temporary error (should reconnect)
     ServerTemporaryError,
@@ -17,7 +18,7 @@ pub enum WebsocketConnectionFailureReason {
     AuthenticationFailure,
     /// Protocol violation (should not reconnect)
     ProtocolViolation,
-    /// Configuration error (should not reconnect)  
+    /// Configuration error (should not reconnect)
     ConfigurationError,
     /// User initiated close (should not reconnect)
     UserInitiatedClose,
@@ -45,6 +46,7 @@ impl WebsocketConnectionFailureReason {
                 }
             }
             Error::Tls(_) | Error::Capacity(_) | Error::Url(_) => Self::ConfigurationError,
+            Error::Protocol(ProtocolError::ResetWithoutClosingHandshake) => Self::UnexpectedClose,
             Error::Protocol(_) | Error::Utf8 | Error::HttpFormat(_) => Self::ProtocolViolation,
             Error::Http(_) => Self::ServerTemporaryError,
             _ => Self::NetworkInterruption,

--- a/src/common/websocket.rs
+++ b/src/common/websocket.rs
@@ -4953,13 +4953,14 @@ mod tests {
                     let addr = listener.local_addr().unwrap();
                     tokio::spawn(async move {
                         if let Ok((stream, _)) = listener.accept().await {
-                            let mut ws = accept_async(stream).await.unwrap();
-                            ws.close(Some(tungstenite::protocol::CloseFrame {
-                                code: tungstenite::protocol::frame::coding::CloseCode::Abnormal,
-                                reason: "oops".into(),
-                            }))
-                            .await
-                            .ok();
+                            let ws = accept_async(stream).await.unwrap();
+
+                            // Explicitly sending an AbnormalClose (1006) is not allowed by the websocket
+                            // protocol and will be converted into Protocol (1002), which the client receives.
+                            //
+                            // Abruptly dropping the connection simulates a real abnormal close, which is
+                            // handled as an error in the websocket protocol
+                            drop(ws);
                         }
                     });
                     let conn = WebsocketConnection::new("c-close");
@@ -9543,9 +9544,9 @@ mod tests {
             let reason = WebsocketConnectionFailureReason::from_tungstenite_error(&error);
             assert!(matches!(
                 reason,
-                WebsocketConnectionFailureReason::ProtocolViolation
+                WebsocketConnectionFailureReason::UnexpectedClose
             ));
-            assert!(!reason.should_reconnect());
+            assert!(reason.should_reconnect());
 
             // UTF8 error -> ProtocolViolation
             let error = TungsteniteError::Utf8;

--- a/src/common/websocket.rs
+++ b/src/common/websocket.rs
@@ -994,6 +994,7 @@ impl WebsocketCommon {
             let read_url = url.to_string();
 
             spawn(async move {
+                let mut stream_end_reason = None;
                 while let Some(item) = read_half.next().await {
                     match item {
                         Ok(Message::Text(msg)) => {
@@ -1046,6 +1047,7 @@ impl WebsocketCommon {
                                 code,
                                 user_initiated,
                             );
+                            stream_end_reason = Some(failure_reason);
 
                             info!(
                                 "Connection {} received close frame: code={}, reason='{}', classified as {:?}",
@@ -1095,7 +1097,7 @@ impl WebsocketCommon {
                             // Classify the error type for reconnection decision
                             let failure_reason =
                                 WebsocketConnectionFailureReason::from_tungstenite_error(&e);
-
+                            stream_end_reason = Some(failure_reason);
                             error!(
                                 "WebSocket error on {}: {:?}, classified as {:?}",
                                 reader_conn.id, e, failure_reason
@@ -1150,8 +1152,9 @@ impl WebsocketCommon {
                 // Handle case where stream ends unexpectedly (e.g., network disconnection)
                 info!("WebSocket stream ended for connection {}", reader_conn.id);
 
-                // Handle unexpected stream end with same logic as other errors
-                let failure_reason = WebsocketConnectionFailureReason::StreamEnded;
+                // Handle possibly unexpected stream end with same logic as other errors
+                let failure_reason =
+                    stream_end_reason.unwrap_or(WebsocketConnectionFailureReason::StreamEnded);
 
                 info!(
                     "WebSocket stream ended for connection {}, classified as {:?}",
@@ -4550,6 +4553,10 @@ mod tests {
         }
 
         mod init_connect {
+            use std::panic;
+
+            use tokio::sync::mpsc::{channel, error::TryRecvError};
+
             use super::*;
 
             #[test]
@@ -4842,6 +4849,67 @@ mod tests {
                         !st.renewal_pending,
                         "renewal_pending should be cleared in on_open"
                     );
+                });
+            }
+
+            #[test]
+            fn does_not_schedule_reconnect_on_renewal() {
+                TOKIO_SHARED_RT.block_on(async {
+                    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+                    let addr = listener.local_addr().unwrap();
+                    let server_handle = tokio::spawn(async move {
+                        if let Ok((stream, _)) = listener.accept().await {
+                            let _ws = accept_async(stream).await.unwrap();
+                            if let Ok((stream, _)) = listener.accept().await {
+                                let _ws = accept_async(stream).await.unwrap();
+                            }
+                            sleep(Duration::from_secs(10)).await;
+                        }
+                    });
+
+                    let conn = WebsocketConnection::new("c-needs-renew");
+                    let (reconnect_tx, mut reconnect_rx) = channel::<ReconnectEntry>(1);
+                    let (renewal_tx, _renewal_rx) = channel::<(String, String)>(1);
+                    let common = Arc::new(WebsocketCommon {
+                        events: WebsocketEventEmitter::new(),
+                        mode: WebsocketMode::Single,
+                        round_robin_index: AtomicUsize::new(0),
+                        connection_pool: vec![conn.clone()],
+                        reconnect_tx,
+                        renewal_tx,
+                        reconnect_delay: 0,
+                        agent: None,
+                        user_agent: None,
+                    });
+                    let url = format!("ws://{addr}");
+                    let res = common
+                        .clone()
+                        .init_connect(&url, false, Some(conn.clone()))
+                        .await;
+
+                    assert!(res.is_ok());
+
+                    {
+                        let st = conn.state.lock().await;
+                        assert!(st.ws_write_tx.is_some(), "writer should be set");
+                    }
+
+                    common
+                        .clone()
+                        .init_connect(&url, true, Some(conn.clone()))
+                        .await
+                        .expect("Renewal init_connect should succeed");
+
+                    sleep(Duration::from_millis(1000)).await;
+
+                    match reconnect_rx.try_recv() {
+                        Err(TryRecvError::Empty) => {}
+                        Ok(_) => panic!("Received reconnection request on renewal"),
+                        Err(TryRecvError::Disconnected) => {
+                            panic!("Sender for reconnection_rx disconnected")
+                        }
+                    }
+                    server_handle.abort();
                 });
             }
 


### PR DESCRIPTION
# Problem

When renewing a websocket connection after 23hrs, the previous connection still schedules a reconnect after it closes. 

This causes the stream to end up with duplicate subscription events. Instead of receiving 1 of each event, 2 are received (I don't know if this further compounds with each renewal). 

I put a bit more info, and a minimal repro example, in #96 

# Root Cause

When closing the old connection, a `NormalClose` event is sent, which shouldn't reconnect. 

However, the close reason is completely ignored after the stream loop ends because it's always set to `StreamEnded` [here](https://github.com/binance/binance-connector-rust/blob/7f4000a0e8875939fe490179d00143d352632d5a/src/common/websocket.rs#L1154).

# Fix

Keep track of the real close reason, and only fall back to `StreamEnded` if it hasn't been set. 

This also meant I had to modify the abnormal close test slightly. It would try to explicitly send an AbormalClose code (1006) from the server, but sending this close code is actually a protocol violation, so the client was receiving `ProtocolViolation`, which isn't set to reconnect. 

When the connection closes abnormally, it's actually handled as an error by the client. 

After changing the test to drop the websocket server and simulate a real abnormal close, I could see the error received was `ProtocolViolation::ResetWithoutClosingHandshake`, and all protocol violation errors were converted to `ProtocolViolation` close reason, which doesn't reconnect. 

So I also changed the error -> close_code conversion logic slightly to convert a `ResetWithoutClosingHandshake` error to `UnexpectedClose`. 

You may want to convert some other error types to `UnexpectedClose` also, but I figured I'd make as few changes to that as possible. 

# Testing

Added a unit test that verifies no reconnect is scheduled on renewal. Ran it before and after the fix to verify it works. 

Also ran some local testing with my minimal repro, and hardcoded the renewal time to 60s instead of 23hrs.

Before the fix: 
```
[2026-05-23T13:11:36.007771Z] 9.70/s
[2026-05-23T13:11:46.00954Z] 10.00/s
[2026-05-23T13:11:56.011531Z] 10.00/s
[2026-05-23T13:12:06.016065Z] 10.00/s
[2026-05-23T13:12:16.016321Z] 10.00/s

*********
CONNECTION SHOULD RENEW NOWISH
*********

[2026-05-23T13:12:26.01947Z] 10.00/s
[2026-05-23T13:12:36.022202Z] 11.90/s
[2026-05-23T13:12:46.024318Z] 20.00/s
[2026-05-23T13:12:56.027016Z] 20.00/s
```

After the fix:

```
[2026-05-23T13:16:03.431574Z] 9.70/s
[2026-05-23T13:16:13.433882Z] 10.00/s
[2026-05-23T13:16:23.434499Z] 10.00/s
[2026-05-23T13:16:33.437015Z] 10.00/s
[2026-05-23T13:16:43.43823Z] 10.00/s

*********
CONNECTION SHOULD RENEW NOWISH
*********

[2026-05-23T13:16:53.439897Z] 10.00/s
[2026-05-23T13:17:03.442264Z] 10.20/s
[2026-05-23T13:17:13.4449Z] 10.00/s
[2026-05-23T13:17:23.446827Z] 10.00/s
[2026-05-23T13:17:33.447778Z] 10.00/s
```

No more duplicate subscriptions


---


Resolves #96 